### PR TITLE
A Capitulo cum Dominica primæ classis

### DIFF
--- a/web/cgi-bin/horas/horascommon.pl
+++ b/web/cgi-bin/horas/horascommon.pl
@@ -888,7 +888,7 @@ sub concurrence {
     #  before DA, more Semiduplex and Duplex where treated as "A capitulo"
     # In Cisterciense, even MM. maj is A capitulo in concurrence with Dom. I. classis
     my $flrank =
-        ($version =~ /cist/i && $cwinner{Rank} =~ /Dominica/i && $dayname[0] =~ /Adv1|Quad[156]/)
+        ($version =~ /cist/i && $cwinner{Rank} =~ /Dominica/i && $tomorrowname[0] =~ /Adv1|Quad[156]/)
       ? ($rank < 4.9 ? 2 : $rank)
       : $version =~ /trident/i ? (
           ($rank < 2.9 && !($rank == 2.1 && $winner{Rank} !~ /infra Octavam/i)) ? 2


### PR DESCRIPTION
> Nice! Yes, the Vigil of Imm. Conception is now working correctly. The caption above on the page says there is a Commemoration of Feria, but luckily it's not in the text of the Office. When I have time, I will go through several offices to look, what works and what not.

As of now, I cannot delete the Feria completely as it is required for the reference to Psalterium to work. At the same time, I suppresed the commemoration by hard rule now. 

> There is one thing that doesn't work and didn't before either. This year, the second Vesper of St. Andrew is also the first Vesper of the First Advent Sunday. According to the rubrics, the First Advent Sunday is one of the major ones, on the level of Serm. maj. with Responsorium prolixum on first Vespers, but as it has ferial Psalms, it should be only a capitulo, and the Psalms + Antiphons should be from St. Andrew. In my fork, I simply changed the rank of Adv1-0.txt to 4 (equal to MM. maj.), and it works. I can afford to do it here, because there is no Festum Sermonis here, that would trump the Sunday.

That's funny, because I thought I had done that in one of my first development steps for the Cistercian. Seems like I never actually tested it and forgot that the `dayname` I was testing for is still the one from the preceding Saturday. (Fixed with this PR).

> St. Peter Chrysolog should be commemorated on Dec. 4th, and the funny thing is, that as a 3-Lesson feast, it should be commemorated before the Advent Feria. So you got it correctly. In the past, this feast was being moved all over the place because of St. Barbara, but now we just commemorate it on its proper place.

Noted. Glad I've put in the right spot by accident.

> Yes, I saw the workaround and I have no idea those tags exist and work :-)

I have introduced the `(feria 2)` magic comments recently only. It has proved to be quite helpful. I am making up new "magic comments" as the development needs them. Luckily, I think I have understood its power now. You can read my summary on the technical page if you are interested: [Technical](https://www.divinumofficium.com/www/horas/Help/technical.html#conditionals)

> Sure, this won't be a problem. So the SanctiM folder will also be merged into the common folder? (it makes sense, and it would make working on a new version quite a bit more convenient...)

- I don't think we can go completely without the SanctiM folder. The differences between 9 and 12 lessons are just too far reaching. For Simples were their are no big differences, however, I already made the script to look in the Roman folder whenever it doesn't find a file in the Monastic.
- I do hope to use the SanctiM folder also for the Cistercian as far as possible. 
- One other important step is going to merge the database for `horas` and `missa`. Keeping the files mostly synchronised is so time consuming.

